### PR TITLE
AST printing and autodiff stepping

### DIFF
--- a/src/core/graph/mod.rs
+++ b/src/core/graph/mod.rs
@@ -11,8 +11,8 @@ pub fn example() {
     let mut ctx = Context::new();
 
     let three = ctx.scalar(3.0);
-    let up = ctx.vector([0.0, 0.0, 1.0]);
-    let id3x3 = ctx.matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
+    //let up = ctx.vector([0.0, 0.0, 1.0]);
+    //let id3x3 = ctx.matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
     let x = ctx.parameter("x");
     let y = ctx.parameter("y");
 
@@ -29,10 +29,10 @@ pub fn example() {
     // let invalid = ctx.add(up, id3x3);
 
     // issue: this also errors, proper dim check is not implemented. see context.rs line 116
-    let matmul = ctx.mul(up, id3x3);
+    //let matmul = ctx.mul(up, id3x3);
 
-    let result = ctx.mul(diff_x, matmul);
+    //let result = ctx.mul(diff_x, matmul);
 
     // output XLA
-    ctx.compile(result);
+    ctx.compile(diff_x);
 }

--- a/src/core/graph/operation.rs
+++ b/src/core/graph/operation.rs
@@ -1,6 +1,6 @@
 use super::{Callsite, Dimension};
 use slotmap::new_key_type;
-use std::fmt::{Display, Error, Formatter, Result};
+use std::fmt::{Display, Formatter, Result};
 use strum_macros::EnumDiscriminants;
 
 /// A node in the compute graph
@@ -41,7 +41,8 @@ pub struct ConstantBinding {
 impl Display for ConstantBinding {
     fn fmt(&self, f: &mut Formatter) -> Result {
         if self.value.is_empty() {
-            return Err(Error);
+            write!(f, "0")?;
+            return Ok(());
         }
         write!(f, "{}", self.value[0])?;
         // TODO: proper matrix printing?


### PR DESCRIPTION
Prints every inbetween step of autodiff process for debugging. Example run:

```
Diff (Add (Mul (Parameter Scalar x) (Constant Scalar 3)) (Parameter Scalar y)) Parameter Scalar x
Add (Diff (Mul (Parameter Scalar x) (Constant Scalar 3)) Parameter Scalar x) (Diff (Parameter Scalar y) Parameter Scalar x)
Add (Add (Mul (Diff (Parameter Scalar x) Parameter Scalar x) (Constant Scalar 3)) (Mul (Parameter Scalar x) (Diff (Constant Scalar 3) Parameter Scalar x))) (Diff (Parameter Scalar y) Parameter Scalar x)
Add (Add (Mul (Constant Scalar 1) (Constant Scalar 3)) (Mul (Parameter Scalar x) (Diff (Constant Scalar 3) Parameter Scalar x))) (Diff (Parameter Scalar y) Parameter Scalar x)  
Add (Add (Mul (Constant Scalar 1) (Constant Scalar 3)) (Mul (Parameter Scalar x) (Constant Scalar 0))) (Diff (Parameter Scalar y) Parameter Scalar x)
Add (Add (Mul (Constant Scalar 1) (Constant Scalar 3)) (Mul (Parameter Scalar x) (Constant Scalar 0))) (Constant Scalar 0)
```

Its possible to verify correctness easier now. Constant propagation will get rid of all the additions by zero and multiplications by one.